### PR TITLE
Add Lean Canvas documentation for EnergyPay

### DIFF
--- a/docs/lean-canvas.md
+++ b/docs/lean-canvas.md
@@ -1,0 +1,82 @@
+# Lean Canvas — EnergyPay
+
+## 1. Problem
+
+Energy markets still rely on fragmented and non-programmable settlement infrastructure.
+
+Main problems:
+- Slow settlement cycles
+- Counterparty and operational risk
+- Limited programmability in financial flows
+- Energy data remains under-monetized
+
+## 2. Customer Segments
+
+Initial target users:
+- Energy retailers / comercializadoras
+- Free market consumers
+- Energy traders
+- Energy data/API consumers
+
+## 3. Unique Value Proposition
+
+Programmable settlement infrastructure for energy markets.
+
+Transforming energy contracts into digital, liquid and programmable financial assets.
+
+EnergyPay enables:
+- Digital energy contracts
+- On-chain settlement
+- Stablecoin-based payments
+- Monetized energy APIs
+
+## 4. Solution
+
+EnergyPay provides:
+- Digital energy contract registry
+- On-chain settlement using Stellar | Stellar-based settlement layer
+- Smart contract verification via Soroban
+- API monetization layer powered by x402
+
+## 5. Channels
+
+Initial channels:
+- Founder-led outreach
+- Energy market network
+- Stellar 37 Degrees ecosystem
+- LinkedIn thought leadership
+- Strategic partnerships with energy retailers
+
+## 6. Revenue
+
+- Transaction fee per settlement
+- API usage fee | API monetization via x402 micropayments
+- SaaS subscription for energy retailers
+- Premium analytics and risk tools
+
+## 7. Cost Structure
+
+Initial cost drivers:
+- Development
+- Cloud infrastructure
+- Blockchain transaction costs
+- Compliance and legal review
+- Customer acquisition
+
+## 8. Key Metrics
+
+Early validation metrics:
+- Number of users interviews
+- Waitlist signups
+- Numbers of Contracts simulated
+- Transactions executed on Stellar
+- API calls monetized (via x402)
+- Early adopter signups
+
+## 9. Unfair Advantage
+
+EnergyPay combines:
+- Deep energy market expertise
+- Stellar-native settlement infrastructure
+- Real-world energy use cases
+- Founder access to energy market participants


### PR DESCRIPTION
Add Lean Canvas documentation to define:
- target persona
- core problem
- proposed solution
- initial MVP scope

This supports Sprint 1 alignment and product definition.